### PR TITLE
Fix proxy is undefined error and remove hardcoded certificate

### DIFF
--- a/scripts/javascript/src/io.js
+++ b/scripts/javascript/src/io.js
@@ -29,6 +29,7 @@ const client = rootPath => (certificatePath, keyPath) => {
   //   port: 3128
   // };
 
+  const proxy = null;
   if (proxy) {
     const httpsAgentOptions = {
       rejectUnauthorized: false,

--- a/scripts/javascript/src/psd2_01A_RequestApplicationToken.js
+++ b/scripts/javascript/src/psd2_01A_RequestApplicationToken.js
@@ -7,10 +7,14 @@ const { getToken, getData } = require('./utils');
 
 const root = join(__dirname, '../../../');
 
-const { baseURL, keyId, tlsCertificateFile, tlsKeyFile, signingKeyFile } = getConfig(root, true);
+const { baseURL, keyId, tlsCertificateFile, tlsKeyFile, signingCertificateFile, signingKeyFile } =
+  getConfig(root, true);
 const clientId = keyId.split(':').join('=');
 
 const signKey = read(join(root, signingKeyFile));
+const signingCertificate = read(join(root, signingCertificateFile)).split('\r\n').join('');
+
+console.log(signingCertificate);
 
 const url = '/oauth2/token';
 const method = 'post';
@@ -33,8 +37,7 @@ const headers = {
   'Content-Type': 'application/x-www-form-urlencoded',
   Digest: digest,
   Date: date,
-  'TPP-Signature-Certificate':
-    '-----BEGIN CERTIFICATE-----MIIENjCCAx6gAwIBAgIEXkKZvjANBgkqhkiG9w0BAQsFADByMR8wHQYDVQQDDBZBcHBDZXJ0aWZpY2F0ZU1lYW5zQVBJMQwwCgYDVQQLDANJTkcxDDAKBgNVBAoMA0lORzESMBAGA1UEBwwJQW1zdGVyZGFtMRIwEAYDVQQIDAlBbXN0ZXJkYW0xCzAJBgNVBAYTAk5MMB4XDTIwMDIxMDEyMTAzOFoXDTIzMDIxMTEyMTAzOFowPjEdMBsGA1UECwwUc2FuZGJveF9laWRhc19xc2VhbGMxHTAbBgNVBGEMFFBTRE5MLVNCWC0xMjM0NTEyMzQ1MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkJltvbEo4/SFcvtGiRCar7Ah/aP0pY0bsAaCFwdgPikzFj+ij3TYgZLykz40EHODtG5Fz0iZD3fjBRRM/gsFPlUPSntgUEPiBG2VUMKbR6P/KQOzmNKF7zcOly0JVOyWcTTAi0VAl3MEO/nlSfrKVSROzdT4Aw/h2RVy5qlw66jmCTcp5H5kMiz6BGpG+K0dxqBTJP1WTYJhcEj6g0r0SYMnjKxBnztuhX5XylqoVdUy1a1ouMXU8IjWPDjEaM1TcPXczJFhakkAneoAyN6ztrII2xQ5mqmEQXV4BY/iQLT2grLYOvF2hlMg0kdtK3LXoPlbaAUmXCoO8VCfyWZvqwIDAQABo4IBBjCCAQIwNwYDVR0fBDAwLjAsoCqgKIYmaHR0cHM6Ly93d3cuaW5nLm5sL3Rlc3QvZWlkYXMvdGVzdC5jcmwwHwYDVR0jBBgwFoAUcEi7XgDA9Cb4xHTReNLETt+0clkwHQYDVR0OBBYEFLQI1Hig4yPUm6xIygThkbr60X8wMIGGBggrBgEFBQcBAwR6MHgwCgYGBACORgEBDAAwEwYGBACORgEGMAkGBwQAjkYBBgIwVQYGBACBmCcCMEswOTARBgcEAIGYJwEDDAZQU1BfQUkwEQYHBACBmCcBAQwGUFNQX0FTMBEGBwQAgZgnAQIMBlBTUF9QSQwGWC1XSU5HDAZOTC1YV0cwDQYJKoZIhvcNAQELBQADggEBAEW0Rq1KsLZooH27QfYQYy2MRpttoubtWFIyUV0Fc+RdIjtRyuS6Zx9j8kbEyEhXDi1CEVVeEfwDtwcw5Y3w6Prm9HULLh4yzgIKMcAsDB0ooNrmDwdsYcU/Oju23ym+6rWRcPkZE1on6QSkq8avBfrcxSBKrEbmodnJqUWeUv+oAKKG3W47U5hpcLSYKXVfBK1J2fnk1jxdE3mWeezoaTkGMQpBBARN0zMQGOTNPHKSsTYbLRCCGxcbf5oy8nHTfJpW4WO6rK8qcFTDOWzsW0sRxYviZFAJd8rRUCnxkZKQHIxeJXNQrrNrJrekLH3FbAm/LkyWk4Mw1w0TnQLAq+s=-----END CERTIFICATE-----',
+  'TPP-Signature-Certificate': signingCertificate,
   'User-Agent': 'openbanking-cli/1.0.0 javascript',
   Authorization: authorization,
 };


### PR DESCRIPTION
- Hardcoded certificate string was expired. I updated the script to read the certificate file and create the string dynamically.
- When trying to run `call_psd2_account_info.js` you would get the following error `ReferenceError: proxy is not defined`. I added a default definition for proxy to be null.