### PR TITLE
Remove certificate content logging

### DIFF
--- a/scripts/javascript/src/psd2_01A_RequestApplicationToken.js
+++ b/scripts/javascript/src/psd2_01A_RequestApplicationToken.js
@@ -14,8 +14,6 @@ const clientId = keyId.split(':').join('=');
 const signKey = read(join(root, signingKeyFile));
 const signingCertificate = read(join(root, signingCertificateFile)).split('\r\n').join('');
 
-console.log(signingCertificate);
-
 const url = '/oauth2/token';
 const method = 'post';
 


### PR DESCRIPTION
A console.log call which had debugging purposes was left in place in the last pull request which was merged. This will remove the call which has no purpose now.